### PR TITLE
fix: improve translation key detection

### DIFF
--- a/src/utilities/locales.ts
+++ b/src/utilities/locales.ts
@@ -153,14 +153,37 @@ function extractStorefrontTranslationKeys(content: string): Set<string> {
 }
 
 function extractUtilityTranslateKeys(content: string): Set<string> {
-  // Find translations assigned to variables first
+  const keys = new Set<string>()
+
+  // Find all key: parameters in utility.translate calls
+  const keyPattern = /render\s+["']utility\.translate["'][\S\s]*?key:\s*["']([^"']+)["']/g
+  const keyMatches = [...content.matchAll(keyPattern)]
+  for (const match of keyMatches) {
+    keys.add(match[1])
+  }
+
+  // Find all t: parameters with string literals
+  const tStringPattern = /render\s+["']utility\.translate["'][\S\s]*?t:\s*["']([^"']+)["']/g
+  const tStringMatches = [...content.matchAll(tStringPattern)]
+  for (const match of tStringMatches) {
+    keys.add(match[1])
+  }
+
+  // Find translations assigned to variables
   const assignedTranslations = findTranslationVariables(content)
 
-  // Find both direct keys and variable-based keys
-  const directKeys = extractDirectUtilityTranslateKeys(content)
-  const variableKeys = extractVariableUtilityTranslateKeys(content, assignedTranslations)
+  // Find variable-based keys in utility.translate
+  const variablePattern = /render\s+["']utility\.translate["'][\S\s]*?t:\s*(\w+)/g
+  const varMatches = [...content.matchAll(variablePattern)]
+  for (const match of varMatches) {
+    const varName = match[1]
+    const translationKey = assignedTranslations.get(varName)
+    if (translationKey) {
+      keys.add(translationKey)
+    }
+  }
 
-  return new Set([...directKeys, ...variableKeys])
+  return keys
 }
 
 function findTranslationVariables(content: string): Map<string, string> {
@@ -174,34 +197,6 @@ function findTranslationVariables(content: string): Map<string, string> {
   }
 
   return assignments
-}
-
-function extractDirectUtilityTranslateKeys(content: string): Set<string> {
-  const keys = new Set<string>()
-  const pattern = /render\s+["']utility.translate["'][^%]*key:\s*["']([^"']+)["']/g
-
-  const matches = [...content.matchAll(pattern)]
-  for (const match of matches) {
-    keys.add(match[1])
-  }
-
-  return keys
-}
-
-function extractVariableUtilityTranslateKeys(content: string, assignedTranslations: Map<string, string>): Set<string> {
-  const keys = new Set<string>()
-  const pattern = /render\s+["']utility.translate["'][^%]*t:\s*([^\s,}]+)/g
-
-  const matches = [...content.matchAll(pattern)]
-  for (const match of matches) {
-    const varName = match[1]
-    const translationKey = assignedTranslations.get(varName)
-    if (translationKey) {
-      keys.add(translationKey)
-    }
-  }
-
-  return keys
 }
 
 export async function removeUnreferencedTranslationsFromTheme(


### PR DESCRIPTION
Use more robust regex patterns with `[\S\s]*?` to match across nested structures and line breaks.

This simplifies the approach to extract utility.translate keys by directly searching for key: and t: parameters rather than trying to parse different Liquid block structures separately.